### PR TITLE
Allow tilda to be replaced with user home

### DIFF
--- a/idr-gcp-storage/src/main/java/com/idrsolutions/microservice/storage/GCPStorage.java
+++ b/idr-gcp-storage/src/main/java/com/idrsolutions/microservice/storage/GCPStorage.java
@@ -104,10 +104,14 @@ public class GCPStorage extends BaseStorage {
         String error = "";
 
         // storageprovider.gcp.credentialspath
-        final String credentialspath = propertiesFile.getProperty("storageprovider.gcp.credentialspath");
+        String credentialspath = propertiesFile.getProperty("storageprovider.gcp.credentialspath");
         if (credentialspath == null || credentialspath.isEmpty()) {
             error += "storageprovider.gcp.credentialspath must have a value\n";
         } else {
+            if (credentialspath.startsWith("~")) {
+                credentialspath = System.getProperty("user.home") + credentialspath.substring(1);
+                propertiesFile.setProperty("storageprovider.gcp.credentialspath", credentialspath);
+            }
             File credentialsFile = new File(credentialspath);
             if (!credentialsFile.exists() || !credentialsFile.isFile() || !credentialsFile.canRead()) {
                 error += "storageprovider.gcp.credentialspath must point to a valid credentials file that can be accessed";

--- a/idr-oracle-storage/src/main/java/com/idrsolutions/microservice/storage/OracleStorage.java
+++ b/idr-oracle-storage/src/main/java/com/idrsolutions/microservice/storage/OracleStorage.java
@@ -148,10 +148,14 @@ public class OracleStorage extends BaseStorage {
         String error = "";
 
         // storageprovider.oracle.ociconfigfilepath
-        final String ociconfigfilepath = propertiesFile.getProperty("storageprovider.oracle.ociconfigfilepath");
+        String ociconfigfilepath = propertiesFile.getProperty("storageprovider.oracle.ociconfigfilepath");
         if (ociconfigfilepath == null || ociconfigfilepath.isEmpty()) {
             error += "storageprovider.oracle.ociconfigfilepath must have a value\n";
         } else {
+            if (ociconfigfilepath.startsWith("~")) {
+                ociconfigfilepath = System.getProperty("user.home") + ociconfigfilepath.substring(1);
+                propertiesFile.setProperty("storageprovider.oracle.ociconfigfilepath", ociconfigfilepath);
+            }
             File configFile = new File(ociconfigfilepath);
             if (!configFile.exists() || !configFile.isFile() || !configFile.canRead()) {
                 error += "storageprovider.oracle.ociconfigfilepath must point to a valid config file that can be accessed";


### PR DESCRIPTION
@JacobIDR Can you confirm this change.
Our other paths allow the use of Tilde to denote user home but does not work on Windows so we manually substitute.

I have updated the two storage options that use paths to work with tilde